### PR TITLE
Fix cpu.md misinfo/typo

### DIFF
--- a/content/cpu.md
+++ b/content/cpu.md
@@ -12,7 +12,7 @@ The CPU is a 16.78 MHz ARM7tdmi RISC processor. It is a 32-bit processor but can
 
 ## CPU Registers
 
-16 registers are visible to the user at any given time, though there are 20 [banked registers](#banked-registers) which get swapped in whenever the CPU changes to various priveleged modes. The registers visible in user mode are as follows:
+17 registers are visible to the user at any given time, though there are 20 [banked registers](#banked-registers) which get swapped in whenever the CPU changes to various priveleged modes. The registers visible in user mode are as follows:
 
 * **r0-r12:** General purpose registers, for use in every day operations
 


### PR DESCRIPTION
The ARM7TDMI has 37 registers. You can reference the technical manual (Section 2.6) for more information. You can also count out the registers already listed.